### PR TITLE
Update libxgboost.dll to latest gpu enabled version.

### DIFF
--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -79,6 +79,8 @@ namespace XGBoost
       parameters["n_estimators"] = nEstimators;
       parameters["silent"] = silent;
       parameters["objective"] = objective;
+      parameters["booster"] = "gbtree";
+      parameters["tree_method"] = "auto";
 
       parameters["nthread"] = nThread;
       parameters["gamma"] = gamma;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -76,6 +76,8 @@ namespace XGBoost
       parameters["n_estimators"] = nEstimators;
       parameters["silent"] = silent;
       parameters["objective"] = objective;
+      parameters["booster"] = "gbtree";
+      parameters["tree_method"] = "auto";
 
       parameters["nthread"] = nThread;
       parameters["gamma"] = gamma;

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -83,7 +83,9 @@ namespace XGBoost.lib
       SetParameter("n_estimators", ((int)parameters["n_estimators"]).ToString());
       SetParameter("silent", ((bool)parameters["silent"]).ToString());
       SetParameter("objective", (string)parameters["objective"]);
-        
+      SetParameter("booster", (string)parameters["booster"]);
+      SetParameter("tree_method", (string)parameters["tree_method"]);
+
       SetParameter("nthread", ((int)parameters["nthread"]).ToString());
       SetParameter("gamma", ((float)parameters["gamma"]).ToString(nfi));
       SetParameter("min_child_weight", ((int)parameters["min_child_weight"]).ToString());
@@ -98,6 +100,8 @@ namespace XGBoost.lib
       SetParameter("base_score", ((float)parameters["base_score"]).ToString(nfi));
       SetParameter("seed", ((int)parameters["seed"]).ToString());
       SetParameter("missing", ((float)parameters["missing"]).ToString(nfi));
+      
+      
       if (parameters.TryGetValue("num_class",out var value))
       {
           numClass = (int)value;


### PR DESCRIPTION
Hi @gatapia ,

Again, thanks for the great work on this xgboost wrapper for .net!

If you are willing to accept pull requests, I have updated the xgboost dll to the latest GPU enabled build from: [xgboost-windows-x64-binaries-for-download](http://www.picnet.com.au/blogs/guido/2016/09/22/xgboost-windows-x64-binaries-for-download/).

I have also added support for the following parameters in Booster.cs:
 - "booster" to enable selection of booster type: "gbtree", "gblinear" or "dart"
 - "tree_method" to enable selection of tree method (this enables GPU use): "auto", "exact", "approx", "hist", "gpu_exact", "gpu_hist".

For now, I have simply hardcoded the default values for the these parameters in `XGBClassifier` and `XGBRegressor` to keep the existing behavior. Let me know if you want me to add them as arguments.

best regards
Mads

