### PR TITLE
Fix booster dispose

### DIFF
--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -187,7 +187,7 @@ namespace XGBoost.lib
     protected virtual void Dispose(bool disposing)
     {
       if (disposed) return;
-      XGBOOST_NATIVE_METHODS.XGDMatrixFree(handle);
+      XGBOOST_NATIVE_METHODS.XGBoosterFree(handle);
       disposed = true;
     }
   }


### PR DESCRIPTION
Hi @gatapia ,

It seems that the `Booster.Dispose()` method called the wrong XGBoost free operation. `XGDMatrixFree` instead of `XGBoosterFree`.

This would cause memory issues when using the library with GPU and training multiple models. For instance when tuning hyper parameters.

Hope you will accept the fix.
Best regards
Mads