### PR TITLE
Add paramters for DART booster

### DIFF
--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -98,7 +98,6 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
-      parameters["updater"] = "shotgun";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
@@ -164,7 +163,6 @@ namespace XGBoost
         ["rate_drop"] = 0.0f,
         ["one_drop"] = 0,
         ["skip_drop"] = 0f,
-        ["updater"] = "shotgun",
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -98,6 +98,7 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
+      parameters["updater"] = "shotgun";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
@@ -163,6 +164,7 @@ namespace XGBoost
         ["rate_drop"] = 0.0f,
         ["one_drop"] = 0,
         ["skip_drop"] = 0f,
+        ["updater"] = "shotgun",
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -96,6 +96,7 @@ namespace XGBoost
       parameters["sample_type"] = "uniform";
       parameters["normalize_type"] = "tree";
       parameters["rate_drop"] = 0.0;
+      parameters["one_drop"] = 0;
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
@@ -159,6 +160,7 @@ namespace XGBoost
         ["sample_type"] = "uniform",
         ["normalize_type"] = "tree",
         ["rate_drop"] = 0.0,
+        ["one_drop"] = 0,
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -95,8 +95,9 @@ namespace XGBoost
 
       parameters["sample_type"] = "uniform";
       parameters["normalize_type"] = "tree";
-      parameters["rate_drop"] = 0.0;
+      parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
+      parameters["skip_drop"] = 0f;
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
@@ -159,8 +160,9 @@ namespace XGBoost
         ["scale_pos_weight"] = 1,
         ["sample_type"] = "uniform",
         ["normalize_type"] = "tree",
-        ["rate_drop"] = 0.0,
+        ["rate_drop"] = 0.0f,
         ["one_drop"] = 0,
+        ["skip_drop"] = 0f,
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -93,6 +93,7 @@ namespace XGBoost
       parameters["reg_lambda"] = regLambda;
       parameters["scale_pos_weight"] = scalePosWeight;
 
+      parameters["sample_type"] = "uniform";
       parameters["rate_drop"] = 0.0;
 
       parameters["base_score"] = baseScore;
@@ -154,6 +155,8 @@ namespace XGBoost
         ["reg_alpha"] = 0,
         ["reg_lambda"] = 1,
         ["scale_pos_weight"] = 1,
+        ["sample_type"] = "uniform",
+        ["rate_drop"] = 0.0,
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -93,6 +93,8 @@ namespace XGBoost
       parameters["reg_lambda"] = regLambda;
       parameters["scale_pos_weight"] = scalePosWeight;
 
+      parameters["rate_drop"] = 0.0;
+
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
       parameters["missing"] = missing;

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -140,6 +140,8 @@ namespace XGBoost
         ["n_estimators"] = 100,
         ["silent"] = true,
         ["objective"] = "binary:logistic",
+        ["booster"] = "gbtree",
+        ["tree_method"] = "auto",
         ["nthread"] = -1,
         ["gamma"] = 0,
         ["min_child_weight"] = 1,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -94,6 +94,7 @@ namespace XGBoost
       parameters["scale_pos_weight"] = scalePosWeight;
 
       parameters["sample_type"] = "uniform";
+      parameters["normalize_type"] = "tree";
       parameters["rate_drop"] = 0.0;
 
       parameters["base_score"] = baseScore;
@@ -156,6 +157,7 @@ namespace XGBoost
         ["reg_lambda"] = 1,
         ["scale_pos_weight"] = 1,
         ["sample_type"] = "uniform",
+        ["normalize_type"] = "tree",
         ["rate_drop"] = 0.0,
         ["base_score"] = 0.5f,
         ["seed"] = 0,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -163,6 +163,7 @@ namespace XGBoost
         ["rate_drop"] = 0.0f,
         ["one_drop"] = 0,
         ["skip_drop"] = 0f,
+        ["updater"] = "grow_colmaker,prune",
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBClassifier.cs
+++ b/XGBoost/XGBClassifier.cs
@@ -163,7 +163,6 @@ namespace XGBoost
         ["rate_drop"] = 0.0f,
         ["one_drop"] = 0,
         ["skip_drop"] = 0f,
-        ["updater"] = "grow_colmaker,prune",
         ["base_score"] = 0.5f,
         ["seed"] = 0,
         ["missing"] = float.NaN,

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -95,6 +95,7 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
+      parameters["updater"] = "grow_colmaker,prune";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -90,6 +90,8 @@ namespace XGBoost
       parameters["reg_lambda"] = regLambda;
       parameters["scale_pos_weight"] = scalePosWeight;
 
+      parameters["rate_drop"] = 0.0;
+
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;
       parameters["missing"] = missing;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -92,8 +92,9 @@ namespace XGBoost
 
       parameters["sample_type"] = "uniform";
       parameters["normalize_type"] = "tree";
-      parameters["rate_drop"] = 0.0;
+      parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
+      parameters["skip_drop"] = 0f;
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -91,6 +91,7 @@ namespace XGBoost
       parameters["scale_pos_weight"] = scalePosWeight;
 
       parameters["sample_type"] = "uniform";
+      parameters["normalize_type"] = "tree";
       parameters["rate_drop"] = 0.0;
 
       parameters["base_score"] = baseScore;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -93,6 +93,7 @@ namespace XGBoost
       parameters["sample_type"] = "uniform";
       parameters["normalize_type"] = "tree";
       parameters["rate_drop"] = 0.0;
+      parameters["one_drop"] = 0;
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -90,6 +90,7 @@ namespace XGBoost
       parameters["reg_lambda"] = regLambda;
       parameters["scale_pos_weight"] = scalePosWeight;
 
+      parameters["sample_type"] = "uniform";
       parameters["rate_drop"] = 0.0;
 
       parameters["base_score"] = baseScore;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -95,7 +95,6 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
-      parameters["updater"] = "grow_colmaker,prune";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -95,6 +95,7 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
+      parameters["updater"] = "shotgun";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/XGBRegressor.cs
+++ b/XGBoost/XGBRegressor.cs
@@ -95,7 +95,6 @@ namespace XGBoost
       parameters["rate_drop"] = 0f;
       parameters["one_drop"] = 0;
       parameters["skip_drop"] = 0f;
-      parameters["updater"] = "shotgun";
 
       parameters["base_score"] = baseScore;
       parameters["seed"] = seed;

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -101,8 +101,9 @@ namespace XGBoost.lib
       SetParameter("seed", ((int)parameters["seed"]).ToString());
       SetParameter("missing", ((float)parameters["missing"]).ToString(nfi));
       
+      SetParameter("sample_type", (string)parameters["sample_type"]);  
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
-      
+
       if (parameters.TryGetValue("num_class",out var value))
       {
           numClass = (int)value;
@@ -127,6 +128,8 @@ namespace XGBoost.lib
       Console.WriteLine("n_estimators: " + (int)parameters["n_estimators"]);
       Console.WriteLine("silent: " + (bool)parameters["silent"]);
       Console.WriteLine("objective: " + (string)parameters["objective"]);
+      Console.WriteLine("booster: " + (string)parameters["booster"]);
+      Console.WriteLine("tree_method: " + (string)parameters["tree_method"]);
 
       Console.WriteLine("nthread: " + (int)parameters["nthread"]);
       Console.WriteLine("gamma: " + (float)parameters["gamma"]);
@@ -142,6 +145,10 @@ namespace XGBoost.lib
       Console.WriteLine("base_score: " + (float)parameters["base_score"]);
       Console.WriteLine("seed: " + (int)parameters["seed"]);
       Console.WriteLine("missing: " + (float)parameters["missing"]);
+
+      Console.WriteLine("sample_type: " + ((float)parameters["sample_type"]));
+      Console.WriteLine("rate_drop: ", + ((float)parameters["rate_drop"]));
+
     }
 
     public void SetParameter(string name, string val)

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -106,6 +106,7 @@ namespace XGBoost.lib
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
       SetParameter("one_drop", ((int)parameters["one_drop"]).ToString());
       SetParameter("skip_drop", ((float)parameters["skip_drop"]).ToString(nfi));
+      SetParameter("updater", ((string)parameters["updater"]));
 
       if (parameters.TryGetValue("num_class",out var value))
       {

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -101,6 +101,7 @@ namespace XGBoost.lib
       SetParameter("seed", ((int)parameters["seed"]).ToString());
       SetParameter("missing", ((float)parameters["missing"]).ToString(nfi));
       
+      SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
       
       if (parameters.TryGetValue("num_class",out var value))
       {

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -105,6 +105,7 @@ namespace XGBoost.lib
       SetParameter("normalize_type ", (string)parameters["normalize_type"]);
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
       SetParameter("one_drop", ((int)parameters["one_drop"]).ToString());
+      SetParameter("skip_drop", ((float)parameters["skip_drop"]).ToString(nfi));
 
       if (parameters.TryGetValue("num_class",out var value))
       {
@@ -152,6 +153,7 @@ namespace XGBoost.lib
       Console.WriteLine("normalize_type: " + ((float)parameters["normalize_type"]));
       Console.WriteLine("rate_drop: ", + ((float)parameters["rate_drop"]));
       Console.WriteLine("one_drop: ", +((int)parameters["one_drop"]));
+      Console.WriteLine("skip_drop: ", +((float)parameters["skip_drop"]));
     }
 
     public void SetParameter(string name, string val)

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -101,7 +101,8 @@ namespace XGBoost.lib
       SetParameter("seed", ((int)parameters["seed"]).ToString());
       SetParameter("missing", ((float)parameters["missing"]).ToString(nfi));
       
-      SetParameter("sample_type", (string)parameters["sample_type"]);  
+      SetParameter("sample_type", (string)parameters["sample_type"]);
+      SetParameter("normalize_type ", (string)parameters["normalize_type"]);
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
 
       if (parameters.TryGetValue("num_class",out var value))
@@ -147,8 +148,8 @@ namespace XGBoost.lib
       Console.WriteLine("missing: " + (float)parameters["missing"]);
 
       Console.WriteLine("sample_type: " + ((float)parameters["sample_type"]));
+      Console.WriteLine("normalize_type: " + ((float)parameters["normalize_type"]));
       Console.WriteLine("rate_drop: ", + ((float)parameters["rate_drop"]));
-
     }
 
     public void SetParameter(string name, string val)

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -104,6 +104,7 @@ namespace XGBoost.lib
       SetParameter("sample_type", (string)parameters["sample_type"]);
       SetParameter("normalize_type ", (string)parameters["normalize_type"]);
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
+      SetParameter("one_drop", ((int)parameters["one_drop"]).ToString());
 
       if (parameters.TryGetValue("num_class",out var value))
       {
@@ -150,6 +151,7 @@ namespace XGBoost.lib
       Console.WriteLine("sample_type: " + ((float)parameters["sample_type"]));
       Console.WriteLine("normalize_type: " + ((float)parameters["normalize_type"]));
       Console.WriteLine("rate_drop: ", + ((float)parameters["rate_drop"]));
+      Console.WriteLine("one_drop: ", +((int)parameters["one_drop"]));
     }
 
     public void SetParameter(string name, string val)

--- a/XGBoost/lib/Booster.cs
+++ b/XGBoost/lib/Booster.cs
@@ -106,7 +106,6 @@ namespace XGBoost.lib
       SetParameter("rate_drop", ((float)parameters["rate_drop"]).ToString(nfi));
       SetParameter("one_drop", ((int)parameters["one_drop"]).ToString());
       SetParameter("skip_drop", ((float)parameters["skip_drop"]).ToString(nfi));
-      SetParameter("updater", ((string)parameters["updater"]));
 
       if (parameters.TryGetValue("num_class",out var value))
       {


### PR DESCRIPTION
Hi @gatapia ,

I have added the missing parameters for when using the DART booster type. For now, I have simply hardcoded the default values in the `XGBoostClassifier` and `XGBoostRegressor`, so behavior should be the same.

I also added the `updater` parameter for the linear booster type, but for some reason it fails when running on GPU, so I ended up removing it again.

Best regards
Mads